### PR TITLE
Copy waflib into build directory

### DIFF
--- a/lib-src/lv2/configure
+++ b/lib-src/lv2/configure
@@ -18,6 +18,11 @@ function waf
    mkdir -p ${pkg}
    pushd >/dev/null ${pkg}
 
+   if [ ! -e "waflib" ]
+   then
+      cp -a "../${srcdir}/${pkg}"/waflib .
+   fi
+   
    for f in "../${srcdir}/${pkg}"/*
    do
       if [ ! -e "${f##*/}" ]


### PR DESCRIPTION
 to prevent python compiler code from poluting source tree.